### PR TITLE
bbcp Seg Fault

### DIFF
--- a/src/bbcp_Node.C
+++ b/src/bbcp_Node.C
@@ -187,7 +187,7 @@ int bbcp_Node::Run(char *user, char *host, char *prog, char *parg)
 // Free up any node name here
 //
    if (nodename) free(nodename);
-   nodename = strdup(host ? host : bbcp_Config.MyHost);
+   nodename = strdup(host ? host : bbcp_Config.MyHost ? bbcp_Config.MyHost : "");
    username = (user ? user : bbcp_Config.MyUser);
 
 // Check for an IPV6 address as ssh does not follow the rfc standard


### PR DESCRIPTION
Fixed issue where bbcp will Seg Fault if it can't resolve host which triggers a strdup(null) call.

Tested on RHEL:
- Changed hostname by editing the file /etc/sysconfig/network and editing the line that starts with 'HOSTNAME='
- Typed the following commands :
echo testfile > ./localfile.txt
bbcp ./localfile.txt user@localhost:.